### PR TITLE
Standardize markdown heading conversion and guidelines

### DIFF
--- a/app/llm.py
+++ b/app/llm.py
@@ -97,6 +97,13 @@ IMPORTANT GUIDELINES:
 10. Address both immediate and long-term management strategies
 11. Do not add any additional sections or explanatory text like "Here is the report in {language} language" or anything like that.
 12. Provide the report in markdown format
+13. Use consistent heading levels throughout the report:
+    - For Diagnostic Report heading, use level 1 heading (#)
+    - Main section titles (1-6) should be level 2 headings (##)
+    - Subsection titles (A, B, C under Management Recommendations) should be level 3 headings (###)
+    - Do not use level 1 headings (#) anywhere in the report except for Diagnostic Report heading
+    - Do not use any heading levels beyond level 3 (###)
+14. Ensure all headings follow this exact format with no variations
 
 Format each section clearly with headers and subheaders for easy reading. Use bullet points for lists and recommendations. Highlight critical information using bold text (**important text**)."""
 

--- a/static/js/markdown-converter.js
+++ b/static/js/markdown-converter.js
@@ -11,30 +11,19 @@ function convertToMarkdown(reportText) {
   let markdownLines = [];
   
   for (let line of lines) {
+    // Check if the line is already a markdown heading (starts with # symbols)
+    if (line.trim().match(/^#{1,6}\s/)) {
+      // Line is already a proper markdown heading, keep it as is
+      markdownLines.push(line);
+    }
     // Convert section headers (lines starting with ** and ending with **)
-    if (line.trim().startsWith('**') && line.trim().endsWith('**')) {
+    else if (line.trim().startsWith('**') && line.trim().endsWith('**')) {
       // Remove the asterisks
       let heading = line.trim().replace(/^\*\*|\*\*$/g, '');
       
-      // Determine heading level based on content
-      if (heading.includes('Diagnostic Report') || heading.includes('Diagnosebericht')) {
-        // Main title - h1
-        markdownLines.push(`# ${heading}`);
-      } else if (heading.includes('Output') || heading.includes('Observations') || 
-                heading.includes('Analysis') || heading.includes('Precautions') || 
-                heading.includes('Solutions') || heading.includes('Cause') ||
-                heading.includes('Modellvorhersage') || heading.includes('Eingangsdaten')) {
-        // Major sections - h2
-        markdownLines.push(`## ${heading}`);
-      } else {
-        // Subsections - h3
-        markdownLines.push(`### ${heading}`);
-      }
+      // Default to h2 for all converted headings for consistency
+      markdownLines.push(`## ${heading}`);
     } 
-    // Handle lines that start with ##
-    else if (line.trim().startsWith('##')) {
-      markdownLines.push(line); // Already in markdown format
-    }
     // Convert list items (lines starting with *)
     else if (line.trim().startsWith('* ')) {
       markdownLines.push(line); // Already in markdown format


### PR DESCRIPTION
- Update llm.py with precise markdown heading guidelines
- Modify markdown-converter.js to:
  * Preserve existing markdown headings
  * Simplify heading conversion logic
  * Use consistent h2 for converted headings
- Ensure consistent markdown formatting across report generation